### PR TITLE
Update TicTacToe.h

### DIFF
--- a/TicTacToe/TicTacToe/TicTacToe.h
+++ b/TicTacToe/TicTacToe/TicTacToe.h
@@ -17,6 +17,8 @@ public:
 			std::cout << "\n\nMain Menu:\n\n1: Singleplayer\n2: Local Multiplayer\n3: Quit\n\nInput: ";
 			std::cin >> input;
 			int numberEntered = input - '0';
+			
+			field.isPlayer1Perspective = false;
 
 			if (numberEntered == 1)
 			{


### PR DESCRIPTION
Wenn man das Spiel startet hat P1 immer 'X'. In der zweiten Runde aber 'O'.
Somit haben die Spieler immer 'X'.